### PR TITLE
Fix promote task

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -127,7 +127,7 @@ promote_task:
     GCF_ACCESS_TOKEN: ENCRYPTED[!1fb91961a5c01e06e38834e55755231d649dc62eca354593105af9f9d643d701ae4539ab6a8021278b8d9348ae2ce8be!]
     PROMOTE_URL: ENCRYPTED[!e22ed2e34a8f7a1aea5cff653585429bbd3d5151e7201022140218f9c5d620069ec2388f14f83971e3fd726215bc0f5e!]
     #artifacts that will have downloadable links in burgr
-    ARTIFACTS: org.sonarsource.config:sonar-config-plugin:jar
+    ARTIFACTS: org.sonarsource.text:sonar-text-plugin:jar
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script: cirrus_promote_maven

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -98,7 +98,7 @@ qa_plugin_task:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
     - cd its/plugin
-    - mvn verify -Pit-plugin -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=${SQ_VERSION} -B -e -V
+    - mvn verify -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=${SQ_VERSION} -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
 
 qa_ruling_task:
@@ -112,7 +112,7 @@ qa_ruling_task:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
     - cd its/ruling
-    - mvn verify -Pit-ruling -Dsonar.runtimeVersion=LATEST_RELEASE[9.2] -B -e -V
+    - mvn verify -Dsonar.runtimeVersion=LATEST_RELEASE[9.2] -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
 
 promote_task:

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -68,7 +68,7 @@ ws_scan_task:
     - build
   <<: *LINUX_1_CPU_1G
   # run only on master and long-term branches
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
+  <<: *QA_TASK_FILTER
   env:
     WS_APIKEY: ENCRYPTED[!3929c6148b9dfc751a2d17c590b15d755f82cd9c108f2de5f24a5b32f2a0c26144e921fab7e2c959fc2824d6d6d1550d!]
   maven_cache:

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -48,14 +48,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>it-plugin</id>
-      <properties>
-        <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-        <skipTests>false</skipTests>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -21,9 +21,9 @@
   </modules>
 
   <properties>
-    <skipTests>true</skipTests>
     <maven.deploy.skip>true</maven.deploy.skip>
     <surefire.argLine>-server</surefire.argLine>
+    <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
   </properties>
 
   <profiles>
@@ -67,14 +67,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>its</id>
-      <properties>
-        <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-        <skipTests>false</skipTests>
-      </properties>
     </profile>
   </profiles>
 

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -34,14 +34,4 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>it-ruling</id>
-            <properties>
-                <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-                <skipTests>false</skipTests>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 
   <modules>
     <module>sonar-text-plugin</module>
-    <module>its</module>
   </modules>
 
   <scm>
@@ -176,5 +175,14 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>include-its</id>
+      <modules>
+        <module>its</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.analyzer-commons</groupId>
-        <artifactId>sonar-analyzer-test-commons</artifactId>
-        <version>${analyzer.commons.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-plugin-api-impl</artifactId>
         <version>${sonar.version}</version>

--- a/sonar-text-plugin/pom.xml
+++ b/sonar-text-plugin/pom.xml
@@ -53,10 +53,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.analyzer-commons</groupId>
-      <artifactId>sonar-analyzer-test-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>


### PR DESCRIPTION
Fix a copy/paste mistake in the promote task and restructure the way we do our QA. Now we hide the `its` module to being part of the main build as well as the WhiteSource scan.