### PR TITLE
fix(ITOPS-3194) Use gh-action_release 4.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        uses: SonarSource/gh-action_release/main@master
+        uses: SonarSource/gh-action_release/main@4.1.0
         with:
           publish_to_binaries: true
           slack_channel: team-lang-phpy
@@ -52,14 +52,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@master
+        uses: SonarSource/gh-action_release/download-build@4.1.0
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@master
+        uses: SonarSource/gh-action_release/maven-central-sync@4.1.0
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@4.1.0
+        uses: SonarSource/gh-action_release/download-build@4.2.0
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@4.1.0
+        uses: SonarSource/gh-action_release/maven-central-sync@4.2.0
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:


### PR DESCRIPTION
Use the most recent tag 4.1.0. 
Important changes are being done on master and will be delivered with new versions (4.2.0). See ITOPS-3194