### PR TITLE
Replace sonar-text-dotnet package licence with GNU Lesser General Public License

### DIFF
--- a/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/LICENSE.txt
+++ b/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/LICENSE.txt
@@ -1,5 +1,0 @@
-﻿Copyright (C) 2021-2023 SonarSource SA
-All rights reserved
-mailto:info AT sonarsource DOT com
-
-This package can be used as part of SonarLint, but can not be copied and/or distributed without the express permission of SonarSource SA.

--- a/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
+++ b/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="..\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup Label="Framework references">


### PR DESCRIPTION
The project `sonar-secrets-dotnet`  is now opensource and thus the old license restriction is not needed anymore.
When the nuget package is now created it includes the license of the sonar-text root directory (GNU Lesser General Public License).