### PR TITLE
Set variables in csproj files from the build command

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -154,7 +154,7 @@ build_and_release_dotnet_task:
   restore_and_build_script:
     # Sets the $BUILD_NUMBER; used for setting the project version.
     # See https://github.com/SonarSource/re-ci-images/blob/master/docker/bin/cirrus-env#L28
-    - source cirrus-env QA 
+    - source cirrus-env QA
     - PowerShell -NonInteractive -NoProfile -File "${PIPELINE_SCRIPTS_DIR}\\build_and_restore_solution.ps1"
   unit_test_script:
     - echo "Running Unit Tests"

--- a/sonar-text-dotnet/pipeline_scripts/build_and_restore_solution.ps1
+++ b/sonar-text-dotnet/pipeline_scripts/build_and_restore_solution.ps1
@@ -3,7 +3,7 @@ Set-Location $env:PROJECT_DIR
 Write-Host Restoring $env:SOLUTION_DIR
 $nugetFeed = "https://pkgs.dev.azure.com/sonarsource/399fb241-ecc7-4802-8697-dcdd01fbb832/_packaging/slvs_input/nuget/v3/index.json"
 # For nuget version see: https://github.com/SonarSource/re-ci-images/blob/master/ec2-images/build-base-windows-dotnet.pkr.hcl#L39
-nuget restore -LockedMode -Source $nugetFeed 
+nuget restore -LockedMode -Source $nugetFeed
 
 Write-Host Building $env:SOLUTION_DIR
 dotnet build `
@@ -16,4 +16,4 @@ dotnet build `
      /p:VisualStudioVersion="17.0" `
      /p:CommitId=$env:CIRRUS_CHANGE_IN_REPO `
      /p:BranchName=$env:CIRRUS_BRANCH `
-     /p:BuildNumber=$BUILD_NUMBER
+     /p:BuildNumber=$env:BUILD_NUMBER

--- a/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
+++ b/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
@@ -14,11 +14,12 @@
 
   <PropertyGroup Label="Versioning - don't edit these values; edit the value in Directory.Build.props instead">
     <!-- The build number and commit id are set by the CI pipeline. -->
+    <BuildNumber>0</BuildNumber>
     <BranchName>not-set</BranchName>
     <CommitId>not-set</CommitId>
-    <AssemblyVersion>$(Version).$(BUILD_NUMBER)</AssemblyVersion>
-    <FileVersion>$(Version).$(BUILD_NUMBER)</FileVersion>
-    <InformationalVersion>$(Version).$(BUILD_NUMBER) Branch: $(CIRRUS_BRANCH) CommitId: $(CIRRUS_CHANGE_IN_REPO) Configuration: $(BUILD_CONFIGURATION)</InformationalVersion>
+    <AssemblyVersion>$(Version).$(BuildNumber)</AssemblyVersion>
+    <FileVersion>$(Version).$(BuildNumber)</FileVersion>
+    <InformationalVersion>$(Version).$(BuildNumber) Branch: $(BranchName) CommitId: $(CommitId) Configuration: $(BUILD_CONFIGURATION)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
+++ b/sonar-text-dotnet/src/SonarLint.Secrets.DotNet/SonarLint.Secrets.DotNet.csproj
@@ -19,7 +19,7 @@
     <CommitId>not-set</CommitId>
     <AssemblyVersion>$(Version).$(BuildNumber)</AssemblyVersion>
     <FileVersion>$(Version).$(BuildNumber)</FileVersion>
-    <InformationalVersion>$(Version).$(BuildNumber) Branch: $(BranchName) CommitId: $(CommitId) Configuration: $(BUILD_CONFIGURATION)</InformationalVersion>
+    <InformationalVersion>$(Version).$(BuildNumber) Branch: $(BranchName) CommitId: $(CommitId) Configuration: $(Configuration)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The env variables in the csproj files should be set by the build command and not directly there.