### PR TITLE
S6694 Improved Mongo DB secret detection precision

### DIFF
--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/mongodb.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/mongodb.yaml
@@ -30,8 +30,10 @@ provider:
           # - ${password}
           # - $(password)
           # - #{password}#
+          # - xxx, ***, ...
           patternNot:
             "(?i)\
+            ^([\\w\\.\\*])\\1{2,}$|\
             ^(\\$[a-z_]*)?(db|my)?_?pass(word|wd)?|\
             ^\\[[\\w\\t \\-]+\\]$|\
             ^<[\\w\\t \\-]+>$|\
@@ -81,6 +83,9 @@ provider:
         - text: |
             CONNECTION_STRING=mongodb://user:#{azure-replacement-token}#@mongo.local:27017/database"
           containsSecret: false
+        - text: |
+            CONNECTION_STRING=mongodb://user:xxx@mongo.local:27017/database"
+          containsSecret: false
 
     - id: mongodb-cli-unquoted
       rspecKey: S6694
@@ -103,8 +108,9 @@ provider:
         post:
           # Avoid matching values found on SourceGraph that look like dummy passwords or insertions.
           patternNot:
-            "^(db|my)?_?pass(word|wd)?$|\
-            ^\\*{3,}$|^\\$[A-Z_]+$|\
+            "^([\\w\\.\\*])\\1{2,}$|\
+            ^(db|my)?_?pass(word|wd)?$|\
+            ^\\$[A-Z_]+$|\
             ^\\$[{(]|^\\{{2,}|\
             ^<[a-z \\-]+>$|\
             ^--[a-z\\-]+$"
@@ -122,6 +128,9 @@ provider:
             mongo --host localhost --username root --password P@ssw0rd
           containsSecret: true
           match: P@ssw0rd
+        - text: |
+            mongo --host localhost --username root --password ***
+          containsSecret: false
 
     - id: mongodb-cli-quoted-outer
       rspecKey: S6694
@@ -144,8 +153,8 @@ provider:
         post:
           # Avoid matching values found on SourceGraph that look like dummy passwords or insertions.
           patternNot:
-            "^(db|my)?_?pass(word|wd)?$|\
-            ^\\*{3,}$|\
+            "^([\\w\\.\\*])\\1{2,}$|\
+            ^(db|my)?_?pass(word|wd)?$|\
             ^\\$[A-Z_]+$|\
             ^\\$[{(]|\
             ^\\{{2,}|\
@@ -165,3 +174,6 @@ provider:
             mongo --host "localhost" --username "root" --password "P@ssw0rd"
           containsSecret: true
           match: P@ssw0rd
+        - text: |
+            mongo --host "localhost" --username "root" --password "..."
+          containsSecret: false


### PR DESCRIPTION
We received feedback via Sonarcloud about Mongo DB placeholder credentials that were detected by rule S6652. The placeholder Mongo DB looked like this:
mongodb://xxx:xxx@mongo:8080/

This PR was created to prevent such false positives in the future.

To prevent this, repeating characters are recognized by the patternNot and will prevent raising issues for passwords like:
- xxx
- \*\*\*
- ...