### PR TITLE
Modify S6703: Remove var substitution FPs APPSEC-1100

### DIFF
--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
@@ -183,16 +183,15 @@ provider:
         post:
           # Avoid matching values found on SourceGraph that look like dummy passwords or insertions.
           patternNot:
-            - "^(?i)pass(word|wd)$"
+            - "^(?i)pass(word|wd)?$"
             - "^(?i)pwd"
             - "^\\[?PLACEHOLDER\\]?$"
             - "^%s$"
             - "^\\*{3,}$"
-            - "^\\{\\d*\\}$"
             - "^\\#\\{"
             - "^\\{{2,}"
             # Support for full and partial substitution
-            - "\\{+[^}]*\\}++"
+            - "\\{+[^}]++\\}+"
             # Azure RM templates
             - "parameters\\(+[^)]*\\)++"
       examples:

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
@@ -193,10 +193,13 @@ provider:
             - "^\\{{2,}"
             # Support for full and partial substitution
             - "\\{+[^}]*\\}++"
+            # Azure RM templates
+            - "parameters\\(+[^)]*\\)++"
       examples:
         - text: |
               "ConnectionStrings": {
                 "DefaultConnection": "Server=tcp:url.windows.example.com,1433;Initial Catalog=sql-example;Persist Security Info=False;User ID={EXAMPLE_USER};Password={PASSWORD_HERE};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;"
+                "sqlConnectionString": "concat('Data Source=',parameters('a'),';Initial Catalog=',parameters('b'),';User ID=',parameters('c'),';Password=',parameters('d'))"
               },
           containsSecret: false
 

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
@@ -191,7 +191,8 @@ provider:
             - "^\\{\\d*\\}$"
             - "^\\#\\{"
             - "^\\{{2,}"
-            - "^\\{+[^}]*\\}++$"
+            # Support for full and partial substitution
+            - "\\{+[^}]*\\}++"
       examples:
         - text: |
               "ConnectionStrings": {

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
@@ -183,8 +183,22 @@ provider:
         post:
           # Avoid matching values found on SourceGraph that look like dummy passwords or insertions.
           patternNot:
-            - "^(?i)pass(word|wd)?(?-i)$|^(?i)pwd(?-i)$|^\\[?PLACEHOLDER\\]?$|^%s$|^\\*{3,}$|^\\{\\d*\\}$|^\\#\\{|^\\{{2,}"
+            - "^(?i)pass(word|wd)$"
+            - "^(?i)pwd"
+            - "^\\[?PLACEHOLDER\\]?$"
+            - "^%s$"
+            - "^\\*{3,}$"
+            - "^\\{\\d*\\}$"
+            - "^\\#\\{"
+            - "^\\{{2,}"
+            - "^\\{+[^}]*\\}++$"
       examples:
+        - text: |
+              "ConnectionStrings": {
+                "DefaultConnection": "Server=tcp:url.windows.example.com,1433;Initial Catalog=sql-example;Persist Security Info=False;User ID={EXAMPLE_USER};Password={PASSWORD_HERE};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;"
+              },
+          containsSecret: false
+
         - text: |
             connStr := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;",
               addr.Host,

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/odbc.yaml
@@ -218,9 +218,17 @@ provider:
               engine="sqlserver2005" />
           containsSecret: false
         - text: |
-            public static string ConnectionString = "server=database-server;uid=sa;pwd=P@ssw0rd;database=ProductionData";
+            // rspec noncompliant example
+            public static string ConnectionString = "server=database-server;uid=user;pwd=P@ssw0rd;database=ProductionData";
           containsSecret: true
           match: P@ssw0rd
+        - text: |
+            // rspec compliant example
+            public static string ConnectionString = String.format(
+                "server=database-server;uid=user;pwd=%s;database=ProductionData",
+                System.getenv("DB_PASSWORD")
+            )
+          containsSecret: false
         - text: |
             env:
               OrchardCore__ConnectionString: "server=database-server;uid=root;pwd=test123;database=test"


### PR DESCRIPTION
This PR fixes False Positives on placeholders resembling `{sonarloris}`. It also adds clarity in the patternNot list