### PR TITLE
Modify S6684: Improve subscription key detections

### DIFF
--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -26,6 +26,67 @@ provider:
           pattern: "['\"`]([a-zA-Z0-9/\\+]{86}==)['\"`]"
       examples:
         - text: |
+            # Noncompliant code example
+            using Azure.Storage.Blobs;
+            using Azure.Storage;
+
+            class Example
+            {
+                static void Main(string[] args)
+                {
+                    string account = "accountname";
+                    string accountKey = "4dVw+l0W8My+FwuZ08dWXn+gHxcmBtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg=="; // Noncompliant
+                    StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(account, accountKey);
+
+                    BlobServiceClient blobServiceClient = new BlobServiceClient(
+                        new Uri($"https://{account}.blob.core.windows.net"),
+                        sharedKeyCredential);
+                }
+            }
+
+          containsSecret: true
+          match: 4dVw+l0W8My+FwuZ08dWXn+gHxcmBtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg==
+
+        - text: |
+            # Compliant solution
+            ## Solution using environment variables:
+            using System;
+            using Azure.Storage.Blobs;
+            using Azure.Storage;
+
+            class Example
+            {
+                static void Main(string[] args)
+                {
+                    string account = Environment.GetEnvironmentVariable("ACCOUNT_NAME");
+                    string accountKey = Environment.GetEnvironmentVariable("ACCOUNT_KEY");
+                    StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(account, accountKey);
+
+                    BlobServiceClient blobServiceClient = new BlobServiceClient(
+                        new Uri($"https://{account}.blob.core.windows.net"),
+                        sharedKeyCredential);
+                }
+            }
+          containsSecret: false
+        - text: |
+            # Compliant solution
+            ## Solution using a passwordless approach, thanks to DefaultAzureCredential:
+            using System;
+            using Azure.Storage.Blobs;
+            using Azure.Identity;
+
+            class Example
+            {
+                static void Main(string[] args)
+                {
+                    string account = Environment.GetEnvironmentVariable("ACCOUNT_NAME");
+                    var blobServiceClient = new BlobServiceClient(
+                            new Uri($"https://{account}.blob.core.windows.net"),
+                            new DefaultAzureCredential());
+                }
+            }
+          containsSecret: false
+        - text: |
             async function main() {
               const account = process.env.ACCOUNT_NAME || "accountname";
               const accountKey = process.env.ACCOUNT_KEY || "4dVw+l0W8My+FwuZ08dWXn+gHxcmBtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg==";
@@ -49,6 +110,7 @@ provider:
         matching:
           pattern: "AccountKey=([a-zA-Z0-9/\\+]{86}==)"
       examples:
+
         - text: |
             const connStr = "DefaultEndpointsProtocol=https;AccountName=testaccountname;AccountKey=4dVw+l0W8My+FwuZ08dWXn+gHxcmBtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg==";
           containsSecret: true

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -1,6 +1,6 @@
 provider:
   metadata:
-    name: Azure 
+    name: Azure
     category: Cloud provider
     message: Make sure this Azure Storage Account Key gets revoked, changed, and removed from the code.
   detection:
@@ -68,7 +68,7 @@ provider:
       detection:
         matching:
           pattern: "AccountKey=([a-zA-Z0-9/\\+]{86}==)"
-    
+
     - id: azure-subscription-keys
       rspecKey: S6684
       metadata:
@@ -77,8 +77,9 @@ provider:
         matching:
           # While pretty generic, looking for this pattern in the wild lands a majority of actual Azure keys.
           # As Azure is Microsoft-oriented, a check for the existence of its KeyVault is added to avoid FPs.
+          # The threshold to 150 characters is used to avoid as big vault urls as possible.
           pattern: "(?is)\
-                    \\w*(?<!@Microsoft.KeyVault\\(SecretUri=https?://[^\\s/$.?#].[^\\s]{1,77})\
+                    \\w*(?<!@Microsoft.KeyVault\\([^)]{1,150})\
                     Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
         post:
           statisticalFilter:
@@ -100,6 +101,7 @@ provider:
         - text: |
               "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key-Dev/e3e56868da48ab516b3538609ec2eb9b)",
               "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key/e3e56868da48ab516b3538609ec2eb9b)",
+              "@Microsoft.KeyVault(VaultName=Example;SecretName=Subscription-Key;SecretVersion=e3e56868da48ab516b3538609ec2eb9b)"
           containsSecret: false
 
     - id: azure-subscription-keys-context-url-before
@@ -119,7 +121,7 @@ provider:
             const string VisionKey2 = "efbb1a98f026d061464af685cd16dcd3";
           containsSecret: true
           match: efbb1a98f026d061464af685cd16dcd3
-        
+
     - id: azure-subscription-keys-context-url-after
       rspecKey: S6684
       metadata:

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -17,6 +17,13 @@ provider:
       id: azure-storage-account-keys-1
       metadata:
         name: Azure Storage Account Keys
+      detection:
+        pre:
+          include:
+            content:
+              - "core.windows.net"
+        matching:
+          pattern: "['\"`]([a-zA-Z0-9/\\+]{86}==)['\"`]"
       examples:
         - text: |
             async function main() {
@@ -33,17 +40,14 @@ provider:
         - text: |
             AccountKey = "BtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg==";
           containsSecret: false
-      detection:
-        pre:
-          include:
-            content:
-              - "core.windows.net"
-        matching:
-          pattern: "['\"`]([a-zA-Z0-9/\\+]{86}==)['\"`]"
+
     - rspecKey: S6338
       id: azure-storage-account-keys-2
       metadata:
         name: Azure Storage Account Keys
+      detection:
+        matching:
+          pattern: "AccountKey=([a-zA-Z0-9/\\+]{86}==)"
       examples:
         - text: |
             const connStr = "DefaultEndpointsProtocol=https;AccountName=testaccountname;AccountKey=4dVw+l0W8My+FwuZ08dWXn+gHxcmBtS7esLAQSrm6/Om3jeyUKKGMkfAh38kWZlItThQYsg31v23A0w/uVP4pg==";
@@ -65,9 +69,6 @@ provider:
             const connStr = "DefaultEndpointsProtocol=https;AccountName=testaccountname;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
           # These are well-known keys used in emulators only
           containsSecret: false
-      detection:
-        matching:
-          pattern: "AccountKey=([a-zA-Z0-9/\\+]{86}==)"
 
     - id: azure-subscription-keys
       rspecKey: S6684
@@ -80,7 +81,7 @@ provider:
           # The threshold to 150 characters is used to avoid as big vault urls as possible.
           pattern: "(?is)\
                     \\w*(?<!@Microsoft.KeyVault\\([^)]{1,150})\
-                    Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
+                    Subscription[_\\-\\.]Key.{1,15}\\b([a-f0-9]{32})\\b"
         post:
           statisticalFilter:
             threshold: 3.0
@@ -103,6 +104,16 @@ provider:
               "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key/e3e56868da48ab516b3538609ec2eb9b)",
               "@Microsoft.KeyVault(VaultName=Example;SecretName=Subscription-Key;SecretVersion=e3e56868da48ab516b3538609ec2eb9b)"
           containsSecret: false
+        - text: |
+            # Noncompliant code example
+            props.set("subscription_key", "efbb1a98f026d061464af685cd16dcd3")
+          containsSecret: true
+          match: efbb1a98f026d061464af685cd16dcd3
+        - text: |
+            # Compliant solution
+            props.set("subscription_key", System.getenv("SUBSCRIPTION_KEY"))
+          containsSecret: false
+
 
     - id: azure-subscription-keys-context-url-before
       rspecKey: S6684

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -63,7 +63,7 @@ provider:
         - text: |
             const connStr = "DefaultEndpointsProtocol=https;AccountName=testaccountname;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
             const connStr = "DefaultEndpointsProtocol=https;AccountName=testaccountname;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
-          # These are well-known keys used in emulators only
+
           containsSecret: false
       detection:
         matching:
@@ -76,7 +76,7 @@ provider:
       detection:
         matching:
           # While pretty generic, looking for this pattern in the wild lands a majority of actual Azure keys.
-          pattern: "(?is)Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
+          pattern: "(?is)Subscription-Key[^\\w]{1,15}\\b([a-f0-9]{32})\\b"
         post:
           statisticalFilter:
             threshold: 3.0
@@ -94,7 +94,10 @@ provider:
             this.bot.add('/', this.dialog);
           containsSecret: true
           match: efbb1a98f026d061464af685cd16dcd3
-      
+        - text: |
+              "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key-Dev/e3e56868da48ab516b3538609ec2eb9b)",
+          containsSecret: false
+
     - id: azure-subscription-keys-context-url-before
       rspecKey: S6684
       metadata:

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -76,7 +76,10 @@ provider:
       detection:
         matching:
           # While pretty generic, looking for this pattern in the wild lands a majority of actual Azure keys.
-          pattern: "(?is)Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
+          # As Azure is Microsoft-oriented, a check for the existence of its KeyVault is added to avoid FPs.
+          pattern: "(?is)\
+                    \\w*(?<!@Microsoft.KeyVault\\(SecretUri=https?://[^\\s/$.?#].[^\\s]{1,77})\
+                    Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
         post:
           statisticalFilter:
             threshold: 3.0

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/azure.yaml
@@ -76,7 +76,7 @@ provider:
       detection:
         matching:
           # While pretty generic, looking for this pattern in the wild lands a majority of actual Azure keys.
-          pattern: "(?is)Subscription-Key[^\\w]{1,15}\\b([a-f0-9]{32})\\b"
+          pattern: "(?is)Subscription-Key.{1,15}\\b([a-f0-9]{32})\\b"
         post:
           statisticalFilter:
             threshold: 3.0
@@ -96,6 +96,7 @@ provider:
           match: efbb1a98f026d061464af685cd16dcd3
         - text: |
               "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key-Dev/e3e56868da48ab516b3538609ec2eb9b)",
+              "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key/e3e56868da48ab516b3538609ec2eb9b)",
           containsSecret: false
 
     - id: azure-subscription-keys-context-url-before


### PR DESCRIPTION
## Why
Fixes FP on 
```

              "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key-Dev/e3e56868da48ab516b3538609ec2eb9b)",
              "SonarService:OcpApimSubscriptionKey": "@Microsoft.KeyVault(SecretUri=https://example.vault.azure.net/secrets/Some-Subscription-Key/e3e56868da48ab516b3538609ec2eb9b)",
              "@Microsoft.KeyVault(VaultName=Example;SecretName=Subscription-Key;SecretVersion=e3e56868da48ab516b3538609ec2eb9b)"
```

and generally improves everything