### PR TITLE
APPSEC-1158: Add patternNot to GitHub secret detection (S6689)

### DIFF
--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/github.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/github.yaml
@@ -22,6 +22,10 @@ provider:
           statisticalFilter:
             threshold: 4.0 # Based on significant sampling, lowest observed entropy is 4.1
             inputString: rand
+          patternNot:
+            - "(\\w)\\1{5}"
+            - "123456"
+            - "(?i)(s|ex)ample"
       examples:
         - text: |
             // noncompliant example
@@ -36,6 +40,9 @@ provider:
             gh_token=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
           containsSecret: true
           match: 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
+        - text: |
+            array('https://***:***@github.com/acme/repo', 'https://ghp_1234567890abcdefghijklmnopqrstuvwxyzAB:x-oauth-basic@github.com/acme/repo'),
+          containsSecret: false
     
     - id: github-fine-grained-tokens
       rspecKey: S6689
@@ -48,6 +55,10 @@ provider:
           statisticalFilter:
             threshold: 4.8 # Based on significant sampling, 4.9 < entropy < 5.6
             inputString: rand # Not sure this is implemented yet. Threshold should be OK with the full candidate
+          patternNot:
+            - "(\\w)\\1{5}"
+            - "123456"
+            - "(?i)(s|ex)ample"
       examples:
         - text: |
             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
@@ -57,6 +68,9 @@ provider:
             TOKEN=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
           containsSecret: true
           match: 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
+        - text: |
+            TOKEN=github_pat_1234567890abcdefg2758f_GiGAWYrCoUUK7ljsOzIlSGJlamMwlWLCPUSKrpBm37sGLUJWG3NSBWcX904
+          containsSecret: false
     
     - id: github-oauth-access-tokens
       rspecKey: S6689
@@ -70,6 +84,10 @@ provider:
         post:
           statisticalFilter:
             threshold: 3.1 # Based on significant sampling, 3.2 < entropy < 3.9
+          patternNot:
+            - "(\\w)\\1{5}"
+            - "123456"
+            - "(?i)(s|ex)ample"
       examples:
         - text: |
             Client_ID: Iv1.5fc06e059d06d826
@@ -86,3 +104,7 @@ provider:
             assertThat(appFromManifest.getClientSecret(), equalTo("9166e8318506a30d43d7a30c76a788fc0ad57a98"));
           containsSecret: true
           match: 9166e8318506a30d43d7a30c76a788fc0ad57a98
+        - text: |
+            assertThat(appFromManifest.getClientId(), equalTo("Iv1.5fc06e059d06d826"));
+            assertThat(appFromManifest.getClientSecret(), equalTo("1234567890123456789030c76a788fc0ad57a98"));
+          containsSecret: false


### PR DESCRIPTION
This PR adds a patternNot filter to the GitHub secret detection to reduce false positives.