### PR TITLE
[APPSEC-966] Fix FP on `env.str(...)`

### DIFF
--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/django.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/django.yaml
@@ -45,10 +45,10 @@ provider:
             # noncompliant example
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = 'r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
+            SECRET_KEY = 's&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
           fileName: settings.py
           containsSecret: true
-          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^
+          match: s&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^
         - text: |
             # compliant example
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
@@ -65,7 +65,7 @@ provider:
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = os.getenv("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
+            SECRET_KEY = os.getenv("SECRET_KEY", "s&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
           fileName: settings.py
           containsSecret: false
         - text: |
@@ -77,7 +77,7 @@ provider:
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = env.str("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
+            SECRET_KEY = env.str("SECRET_KEY", "s&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
           fileName: settings.py
           containsSecret: false
 
@@ -104,7 +104,7 @@ provider:
             # noncompliant example
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = 'r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
+            SECRET_KEY = 'd&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
           fileName: settings.py
           containsSecret: false
         - text: |
@@ -123,10 +123,10 @@ provider:
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = os.getenv("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
+            SECRET_KEY = os.getenv("SECRET_KEY", "d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
           fileName: settings.py
           containsSecret: true
-          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^
+          match: d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
@@ -136,17 +136,17 @@ provider:
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = env("SECRET_KEY", default="r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
+            SECRET_KEY = env("SECRET_KEY", default="d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
           fileName: settings.py
           containsSecret: true
-          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^
+          match: d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = env.str("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^")
+            SECRET_KEY = env.str("SECRET_KEY", "d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^")
           fileName: settings.py
           containsSecret: true
-          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^
+          match: d&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^
 
     - id: env-secret-key
       rspecKey: S6687

--- a/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/django.yaml
+++ b/sonar-text-plugin/src/main/resources/org/sonar/plugins/secrets/configuration/django.yaml
@@ -22,7 +22,7 @@ provider:
           containsSecret: true
           match: django-insecure-r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^
 
-    - id: settings.py-secret-key
+    - id: settings.py-secret-key-string
       rspecKey: S6687
       metadata:
         name: Django secret keys should not be disclosed
@@ -32,7 +32,8 @@ provider:
             paths:
               - "**/settings.py"
         matching:
-          pattern: "\\bSECRET_KEY(?:_FALLBACKS)?\\s*=\\s*(?:os\\.getenv\\(\\s*['\"][^'\"]+['\"]\\s*,\\s*)?['\"]([^'\"]+)"
+          # Only detects secrets presented directly as a string.
+          pattern: "\\bSECRET_KEY(?:_FALLBACKS)?\\s*=\\s*['\"]([^'\"\\r\\n]+)"
           context:
             patternAround: "(?i)\\bdjango"
         post:
@@ -44,10 +45,10 @@ provider:
             # noncompliant example
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = 'r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^'
+            SECRET_KEY = 'r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
           fileName: settings.py
           containsSecret: true
-          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^
+          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^
         - text: |
             # compliant example
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
@@ -60,7 +61,13 @@ provider:
             # SECURITY WARNING: keep the secret key used in production secret!
             SECRET_KEY = os.getenv("SECRET_KEY")
           fileName: settings.py
-          containsSecret: false  
+          containsSecret: false
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = os.getenv("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
+          fileName: settings.py
+          containsSecret: false
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
@@ -70,10 +77,76 @@ provider:
         - text: |
             # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
             # SECURITY WARNING: keep the secret key used in production secret!
-            SECRET_KEY = os.getenv("PASS","r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
+            SECRET_KEY = env.str("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
+          fileName: settings.py
+          containsSecret: false
+
+    - id: settings.py-secret-key-env-default
+      rspecKey: S6687
+      metadata:
+        name: Django secret keys should not be disclosed
+      detection:
+        pre:
+          include:
+            paths:
+              - "**/settings.py"
+        matching:
+          # Only detects secrets presented as a default value to os.environ(), environs.Env() or environs.Env.str()
+          pattern: "\\bSECRET_KEY(?:_FALLBACKS)?\\s*=\\s*(?:os\\.getenv|env(?:\\.str)?)\\(\\s*['\"][^'\"\\r\\n]+['\"]\\s*,\\s*(?:default\\s*=\\s*)?['\"]([^'\"\\r\\n]+)"
+          context:
+            patternAround: "(?i)\\bdjango"
+        post:
+          patternNot:
+            - "(\\w)\\1{4,}"
+            - "(?i)(ex|s)ample"
+      examples:
+        - text: |
+            # noncompliant example
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = 'r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos1_9^'
+          fileName: settings.py
+          containsSecret: false
+        - text: |
+            # compliant example
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = os.environ['SECRET_KEY']
+          fileName: settings.py
+          containsSecret: false
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = os.getenv("SECRET_KEY")
+          fileName: settings.py
+          containsSecret: false
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = os.getenv("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^")
+          fileName: settings.py
+          containsSecret: true
+          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos2_9^
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = env("SECRET_KEY")
+          fileName: settings.py
+          containsSecret: false
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = env("SECRET_KEY", default="r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^")
           fileName: settings.py
           containsSecret: true
           match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos3_9^
+        - text: |
+            # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+            # SECURITY WARNING: keep the secret key used in production secret!
+            SECRET_KEY = env.str("SECRET_KEY", "r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^")
+          fileName: settings.py
+          containsSecret: true
+          match: r&lvybzry1*k+qq)=x-!=0yd5l5#1gxzk!82@ru25*ntos4_9^
 
     - id: env-secret-key
       rspecKey: S6687


### PR DESCRIPTION
https://sonarsource.atlassian.net/browse/APPSEC-966

As noted in [this Sonar Community thread](https://community.sonarsource.com/t/django-secret-key-from-env-file-raising-secrets-s6652/97392), we have a FP where `env.str(...)` is used to pull a secret from the environment.