### PR TITLE
Fix issues with rules being run against examples from other rules.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,11 +46,11 @@ linux_image_template: &LINUX_IMAGE
   namespace: default
   use_in_memory_disk: true
 
-linux_1_cpu_1G_template: &LINUX_1_CPU_1G
+linux_1_cpu_1G_template: &LINUX_1_CPU_2G
   eks_container:
     <<: *LINUX_IMAGE
     cpu: 1
-    memory: 1G
+    memory: 2G
 
 linux_2_cpu_6G_java_17_template: &LINUX_2_CPU_6G_JAVA_17
   eks_container:
@@ -97,7 +97,7 @@ build_task:
 ws_scan_task:
   depends_on:
     - build
-  <<: *LINUX_1_CPU_1G
+  <<: *LINUX_1_CPU_2G
   # run only on master and long-term branches
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
   env:
@@ -143,7 +143,7 @@ promote_task:
     - qa_plugin
     - ws_scan
   <<: *ONLY_IF_SONARSOURCE_QA
-  <<: *LINUX_1_CPU_1G
+  <<: *LINUX_1_CPU_2G
   env:
     #promotion cloud function
     GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]

--- a/sonar-text-plugin/src/test/java/org/sonar/plugins/secrets/utils/AbstractRuleExampleTest.java
+++ b/sonar-text-plugin/src/test/java/org/sonar/plugins/secrets/utils/AbstractRuleExampleTest.java
@@ -55,16 +55,16 @@ public abstract class AbstractRuleExampleTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractRuleExampleTest.class);
   private static SpecificationLoader specificationLoader;
-  private final Check check;
+  private final SpecificationBasedCheck check;
   private final HashMap<URI, List<TextRange>> reportedIssuesForCtx = new HashMap<>();
 
-  protected AbstractRuleExampleTest(Check check) {
+  protected AbstractRuleExampleTest(SpecificationBasedCheck check) {
     if (specificationLoader == null) {
       specificationLoader = new SpecificationLoader();
     }
 
     this.check = check;
-    ((SpecificationBasedCheck) check).initialize(specificationLoader, reportedIssuesForCtx, mockDurationStatistics());
+    check.initialize(specificationLoader, reportedIssuesForCtx, mockDurationStatistics());
   }
 
   @TestFactory
@@ -85,7 +85,7 @@ public abstract class AbstractRuleExampleTest {
       String exampleFileName = ruleExample.getFileName() != null ? ruleExample.getFileName() : "file.txt";
       InputFileContext inputFileContext = new InputFileContext(context, inputFile(Path.of(exampleFileName), ruleExample.getText()));
 
-      check.analyze(inputFileContext);
+      check.analyze(inputFileContext, rule.getId());
 
       Collection<Issue> issues = context.allIssues();
       if (ruleExample.isContainsSecret()) {

--- a/sonar-text-plugin/src/test/java/org/sonar/plugins/secrets/utils/UpdatingSpecificationFilesGenerator.java
+++ b/sonar-text-plugin/src/test/java/org/sonar/plugins/secrets/utils/UpdatingSpecificationFilesGenerator.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -68,12 +69,14 @@ class UpdatingSpecificationFilesGenerator {
 
   // Suppress warning, as there are no assertions inside here
   @Test
+  @Disabled("Should only be triggered manually")
   @SuppressWarnings("java:S2699")
   void firstStep() {
     writeSpecificationFileDefinition();
   }
 
   @Test
+  @Disabled("Should only be triggered manually")
   void secondStep() {
     testDeserializationOfSpecificationFiles();
     SpecificationLoader specificationLoader = new SpecificationLoader();


### PR DESCRIPTION
Examples are associated with rules in the configuration files. The test framework was ignoring this association and was running all rules with the same RSPEC key against every example. This can lead to tests failing because they trigger a different rule than the one the example is for.

This change ensures that only the matching rule is executed.